### PR TITLE
Change className generation and mismatched classNames

### DIFF
--- a/js/src/forum/components/IconSelectorComponent.js
+++ b/js/src/forum/components/IconSelectorComponent.js
@@ -144,7 +144,7 @@ export default class IconSelectorComponent extends Dropdown {
                     role="button"
                     className={classList({
                         'iconpicker-item': true,
-                        'iconpicker--highlighted': this.attrs.selection() === 'favicon',
+                        'iconpicker-item--highlighted': this.attrs.selection() === 'favicon',
                     })}
                     title="Favicon"
                 >
@@ -164,8 +164,8 @@ export default class IconSelectorComponent extends Dropdown {
                     onclick={() => this.select('favicon-grey')}
                     role="button"
                     className={classList({
-                        'iconpicker-item iconpicker-item--invt': true,
-                        'iconpicker--highlighted': this.attrs.selection() === 'favicon-grey',
+                        'iconpicker-item iconpicker-item--invertColors': true,
+                        'iconpicker-item--highlighted': this.attrs.selection() === 'favicon-grey',
                     })}
                     title="Grey Favicon"
                 >
@@ -185,7 +185,7 @@ export default class IconSelectorComponent extends Dropdown {
                 curIcon.replace(/ /, '-'),
                 <div
                     onclick={() => this.select(curIcon)}
-                    className={classList({ 'iconpicker-item': true, 'iconpicker--highlighted': this.attrs.selection() === curIcon })}
+                    className={classList({ 'iconpicker-item': true, 'iconpicker-item--highlighted': this.attrs.selection() === curIcon })}
                     role="button"
                     title={`.${curIcon}`}
                 >

--- a/js/src/forum/components/IconSelectorComponent.js
+++ b/js/src/forum/components/IconSelectorComponent.js
@@ -1,7 +1,7 @@
 import Dropdown from 'flarum/components/Dropdown';
 import ItemList from 'flarum/utils/ItemList';
 import icon from 'flarum/helpers/icon';
-import Stream from 'flarum/utils/Stream';
+import classList from 'flarum/utils/classList';
 
 export default class IconSelectorComponent extends Dropdown {
     static initAttrs(attrs) {
@@ -115,9 +115,12 @@ export default class IconSelectorComponent extends Dropdown {
             /^favicon(-\w+)?$/.test(this.attrs.selection())
                 ? [
                       <img
-                          className={this.attrs.selection() === 'favicon-grey' ? 'social-greyscale-button' : 'social-button'}
-                          style={{ width: '14px', height: '14px' }}
-                          alt="favicon"
+                          className={classList({
+                              'icondropdown-activeIcon': true,
+                              'social-greyscale-button': this.attrs.selection() === 'favicon-grey',
+                              'social-button': !this.attrs.selection() === 'favicon-grey',
+                          })}
+                          alt=""
                           src={this.attrs.favicon()}
                           onerror={() => {
                               this.attrs.favicon('none');
@@ -125,7 +128,7 @@ export default class IconSelectorComponent extends Dropdown {
                           }}
                       />,
                   ]
-                : icon(this.attrs.selection(), {}),
+                : icon(this.attrs.selection(), { className: 'icondropdown-activeIcon fa-fw' }),
             this.attrs.caretIcon ? icon(this.attrs.caretIcon, { className: 'Button-caret' }) : '',
         ];
     }
@@ -139,7 +142,10 @@ export default class IconSelectorComponent extends Dropdown {
                 <div
                     onclick={() => this.select('favicon')}
                     role="button"
-                    className={`iconpicker-item ${this.attrs.selection() === 'favicon' ? 'iconpicker--highlighted' : ''}`}
+                    className={classList({
+                        'iconpicker-item': true,
+                        'iconpicker--highlighted': this.attrs.selection() === 'favicon',
+                    })}
                     title="Favicon"
                 >
                     <img
@@ -157,7 +163,10 @@ export default class IconSelectorComponent extends Dropdown {
                 <div
                     onclick={() => this.select('favicon-grey')}
                     role="button"
-                    className={`iconpicker-item-invt ${this.attrs.selection() === 'favicon-grey' ? 'iconpicker--highlighted' : ''}`}
+                    className={classList({
+                        'iconpicker-item iconpicker-item--invt': true,
+                        'iconpicker--highlighted': this.attrs.selection() === 'favicon-grey',
+                    })}
                     title="Grey Favicon"
                 >
                     <img
@@ -172,16 +181,15 @@ export default class IconSelectorComponent extends Dropdown {
         }
 
         this.icons.social.forEach((curIcon) => {
-            const highlighted = Stream();
-
-            if (this.attrs.selection() === curIcon) {
-                highlighted('iconpicker--highlighted');
-            }
-
             items.add(
                 curIcon.replace(/ /, '-'),
-                <div onclick={() => this.select(curIcon)} className={`iconpicker-item ${highlighted()}`} role="button" title={`.${curIcon}`}>
-                    {icon(curIcon, { className: 'social-icon' })}
+                <div
+                    onclick={() => this.select(curIcon)}
+                    className={classList({ 'iconpicker-item': true, 'iconpicker--highlighted': this.attrs.selection() === curIcon })}
+                    role="button"
+                    title={`.${curIcon}`}
+                >
+                    {icon(curIcon, { className: 'social-icon fa-fw' })}
                 </div>,
                 100
             );

--- a/js/src/forum/components/WebsiteInputComponent.js
+++ b/js/src/forum/components/WebsiteInputComponent.js
@@ -16,7 +16,7 @@ export default class WebsiteInputComponent extends Component {
             <div className="Form-group form-group-social" id={`socialgroup-${this.button.index()}`}>
                 <input
                     type="text"
-                    className="SocialFormControl SocialTitle"
+                    className="SocialFormControl SocialFormControl-title"
                     placeholder={app.translator.trans('fof-socialprofile.forum.edit.title')}
                     tabIndex={(this.button.index() + 1) * 2 - 1}
                     bidi={this.button.title}
@@ -30,18 +30,18 @@ export default class WebsiteInputComponent extends Component {
 
                 <input
                     type="text"
-                    className="SocialFormControl Socialurl"
+                    className="SocialFormControl SocialFormControl-url"
                     placeholder={app.translator.trans('fof-socialprofile.forum.edit.url')}
                     tabIndex={(this.button.index() + 1) * 2}
                     value={this.button.url()}
                     onchange={withAttr('value', this.onUrlChange.bind(this))}
                 />
 
-                <input type="hidden" className="SocialFormControl SocialIcon" id={`icon${this.button.index()}-icon`} bidi={this.button.icon} />
+                <input type="hidden" className="SocialFormControl SocialFormControl-icon" id={`icon${this.button.index()}-icon`} bidi={this.button.icon} />
 
                 <input
                     type="hidden"
-                    className="SocialFormControl Socialfavicon"
+                    className="SocialFormControl SocialFormControl-favicon"
                     id={`icon${this.button.index()}-favicon`}
                     bidi={this.button.favicon}
                 />

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -4,21 +4,13 @@ import { extend } from 'flarum/extend';
 import UserCard from 'flarum/components/UserCard';
 import Badge from 'flarum/components/Badge';
 import ItemList from 'flarum/utils/ItemList';
+import classList from 'flarum/utils/classList';
 
 import SocialButtonsModal from './components/SocialButtonsModal';
 import DeleteButtonModal from './components/DeleteButtonModal';
 
 app.initializers.add('fof/socialprofile', () => {
     User.prototype.socialButtons = Model.attribute('socialButtons', (str) => JSON.parse(str || '[]'));
-
-    // extend(UserCard.prototype, 'init', function () {
-    //     $('#app').on('refreshSocialButtons', (e, buttons) => {
-    //         this.buttons = JSON.parse(buttons || '[]');
-    //         this.attrs.user.socialButtons(this.buttons);
-    //         this.attrs.user.freshness = new Date();
-    //         m.redraw();
-    //     });
-    // });
 
     extend(UserCard.prototype, 'infoItems', function (items) {
         this.isSelf = app.session.user === this.attrs.user;
@@ -31,23 +23,25 @@ app.initializers.add('fof/socialprofile', () => {
             this.buttons.forEach((button, index) => {
                 if (button.title !== '' && button.icon !== '' && button.url !== '') {
                     let buttonStyle = '';
-                    let buttonClassName = '';
+                    let buttonClassName = classList({
+                        [`social-button ${button.icon}-${index} social-icon-${index}`]: true,
+                        'social-greyscale-button': button.icon === 'favicon-grey',
+                    });
 
                     if (button.icon === 'favicon' || button.icon === 'favicon-grey') {
-                        buttonStyle = `background-image: url("${button.favicon}");background-size: 60%;background-position: 50% 50%;background-repeat: no-repeat;`;
-                        if (button.icon === 'favicon-grey') {
-                            buttonClassName = `${button.icon}-${index} social-button social-greyscale-button`;
-                        } else {
-                            buttonClassName = `${button.icon}-${index} social-button`;
-                        }
-                    } else {
-                        buttonStyle = '';
-                        buttonClassName = `${button.icon}-${index} social-button`;
+                        buttonStyle = `
+                            background-image: url("${button.favicon}");
+                            background-size: 60%;
+                            background-position: center;
+                            background-repeat: no-repeat;
+                        `;
                     }
+
                     buttonList.add(
-                        `${buttonClassName}${this.deleting ? ' social-button--highlightable' : ''}`,
+                        `social-icon-${index}`,
                         Badge.component({
-                            type: `social social-icon-${index}`,
+                            className: classList({ [buttonClassName]: true, 'social-icon--deleting': this.deleting }),
+                            type: `social`,
                             icon: button.icon,
                             label: button.title,
                             style: buttonStyle,

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -27,6 +27,10 @@
   padding-bottom: 12px;
   border-bottom: 1px solid rgba(128, 128, 128, 0.2);
 
+  .Button--icon .Button-caret {
+    display: inline-block;
+  }
+
   .SocialFormControl {
     height: 36px;
     padding: 0 13px;
@@ -63,10 +67,6 @@
       width: 36px;
       padding-left: 8px;
       padding-right: 8px;
-
-      .Button--caret {
-        display: inline-block;
-      }
     }
 
     &-item {

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -2,146 +2,164 @@
   background: transparent;
   border: none;
   box-shadow: none;
-  -webkit-box-shadow: none;
   cursor: pointer;
 }
+
 .UserCard-info > .social-button {
   margin-right: 0;
 }
+
 .social-settings > .fa-cog {
   border-left: 1px solid white;
   width: 120%;
 }
+
 .form-group-social {
-  margin-bottom: 15px;
-  padding-bottom: 15px;
-  border-bottom: 2px dashed #4D698E;
-  /*display: none;*/
-}
-.iconpicker-item {
-  float: left;
-  padding: 12px;
-  margin: 0 12px 12px 0;
-  text-align: center;
-  cursor: pointer;
-  border-radius: 3px;
-  font-size: 14px;
-  box-shadow: 0 0 0 1px #ddd;
-  color: #111;
-}
-.iconpicker-item-invt {
-  float: left;
-  padding: 12px;
-  margin: 0 12px 12px 0;
-  text-align: center;
-  cursor: pointer;
-  border-radius: 3px;
-  font-size: 14px;
-  box-shadow: 0 0 0 1px #ddd;
-  color: inherit;
-  background-color: black;
-}
-.iconpicker-item-invt:hover {
-  background-color: #2D2D2D;
-}
-.iconpicker-item:hover {
-  background-color: #F1F1F1;
-}
-.iconpicker--highlighted {
-  background-color: #4D698E;
-  color: white;
-}
-.iconpicker--highlighted:hover, .iconpicker--highlighted:active {
-  background-color: #364A65;
-}
-.social-dropdown-menu {
-  padding-left: 10px !important;
-  padding-top: 10px !important;
-  bottom: inherit !important;
-  position: absolute !important;
-  top: 100% !important;
-  overflow: auto;
-  max-height: 45vh !important;
-  min-width: 190px !important;
-  z-index: 2055;
-  float: left;
-  background-color: #fff;
-  -webkit-background-clip: padding-box;
-  background-clip: padding-box;
-  border: 1px solid rgba(0,0,0,.15);
-  -webkit-transition: none !important;
-  -moz-transition: none !important;
-  -o-transition: none !important;
-  transition: none !important;
-}
-.SocialFormControl {
-  margin-bottom: 5px;
-  width: 100%;
-  height: 36px;
-  padding: 8px 13px;
-  font-size: 13px;
-  line-height: 1.5;
-  background-color: #fff;
-  color: #111;
-  border: 2px solid transparent;
-  border-radius: 4px;
-  -webkit-transition: border-color .15s, background .15s;
-  -o-transition: border-color .15s, background .15s;
-  transition: border-color .15s, background .15s;
-  -webkit-appearance: none;
-}
-.Socialurl {
-  margin-left: 3px;
-  width: 260px;
-}
-@media (max-width: 767px) {
-  .Socialurl {
-    width: 293px;
+  display: grid;
+  grid-template-areas:
+    "titleTextField titleTextField"
+    "dropdown       urlTextField";
+  grid-template-columns: min-content auto;
+  grid-gap: 4px;
+  gap: 4px;
+  margin-bottom: 12px;
+
+  padding-bottom: 12px;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.2);
+
+  .SocialFormControl {
+    height: 36px;
+    padding: 0 13px;
+    font-size: 13px;
+    line-height: 36px;
+    background-color: #fff;
+    color: #111;
+    border: 2px solid transparent;
+    border-radius: 4px;
+    transition: border-color 0.15s, background-color 0.15s;
+
+    &-title {
+      grid-area: titleTextField;
+    }
+
+    &-url {
+      grid-area: urlTextField;
+    }
+  }
+
+  .icondropdown-activeIcon {
+    display: inline-block;
+    vertical-align: middle;
+    font-size: 16px;
+    max-height: 100%;
+    width: 1.25em;
+  }
+
+  .iconpicker {
+    grid-area: dropdown;
+
+    > button {
+      height: 36px;
+      width: 36px;
+      padding-left: 8px;
+      padding-right: 8px;
+
+      .Button--caret {
+        display: inline-block;
+      }
+    }
+
+    &-item {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      padding: 4px;
+      text-align: center;
+      cursor: pointer;
+      border-radius: 3px;
+      font-size: 18px;
+      box-shadow: 0 0 0 1px #ddd;
+      color: #111;
+
+      &:hover,
+      &:focus,
+      &:active {
+        background-color: #f1f1f1;
+      }
+
+      &--highlighted {
+        background-color: #4d698e;
+        color: white;
+
+        &:hover,
+        &:focus,
+        &:active {
+          background-color: #364a65;
+        }
+      }
+    }
   }
 }
+
+.open .social-dropdown-menu {
+  display: grid;
+}
+
+.social-dropdown-menu {
+  overflow: auto;
+  height: 300px;
+  max-height: 45vh;
+  min-height: 100px;
+  z-index: 2055;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  transition: none;
+
+  padding: 8px;
+  grid-template-columns: repeat(3, minmax(10px, 1fr));
+  grid-gap: 8px;
+  gap: 8px;
+
+  > li {
+    // Force square
+    height: 0;
+    padding-bottom: 100%;
+    position: relative;
+  }
+}
+
 .social-greyscale-button {
-  -webkit-filter: grayscale(1) contrast(2) brightness(2);
-  filter: grayscale(1) contrast(2) brightness(2);
+  filter: grayscale(1) brightness(1.5);
 }
-.icondropdown > button {
-  width: 52px !important;
-}
-.icondropdown > button > i {
-  display: inline-block !important;
-}
+
 .social-moderate--highlighted > .Badge-icon {
-  color: #F22613;
-  transition: .5s;
+  color: #f22613;
+  transition: 0.5s;
   font-size: 23px;
-  -webkit-animation: fa-spin 2s infinite linear;
   animation: fa-spin 2s infinite linear;
 }
+
 .social-button--highlightable:hover {
   border-radius: 4px;
-  background: #F22613;
+  background: #f22613;
 }
+
 .fa-pulse {
-  -webkit-animation: fa-spin 1s infinite steps(8);
   animation: fa-spin 1s infinite steps(8);
-}
-@-webkit-keyframes fa-spin {
-  0% {
-    -webkit-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-  100% {
-    -webkit-transform: rotate(359deg);
-    transform: rotate(359deg);
-  }
-}
-@keyframes fa-spin {
-  0% {
-    -webkit-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-  100% {
-    -webkit-transform: rotate(359deg);
-    transform: rotate(359deg);
+
+  @keyframes fa-spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(1turn);
+    }
   }
 }
 

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -51,12 +51,20 @@
     }
   }
 
-  .icondropdown-activeIcon {
-    display: inline-block;
-    vertical-align: middle;
-    font-size: 16px;
-    max-height: 100%;
-    width: 1.25em;
+  .icondropdown {
+    > button {
+      padding-left: 4px;
+      padding-right: 4px;
+      width: auto;
+    }
+
+    &-activeIcon {
+      display: inline-block;
+      vertical-align: middle;
+      font-size: 16px;
+      max-height: 100%;
+      width: 1.25em;
+    }
   }
 
   .iconpicker {


### PR DESCRIPTION
This PR converts the messy string interpolation and concatenation to `flarum/utils/classList` calls. I've also added a couple extra classes to help with styling, as well as fixing some class names which deviate from the format Flarum use.

Styling has been converted to proper Less, compared to the compiled CSS which was present before.

![image](https://user-images.githubusercontent.com/7406822/106680036-bb40bc80-65b5-11eb-8618-352a4f646f24.png)

![image](https://user-images.githubusercontent.com/7406822/106680059-c693e800-65b5-11eb-81da-92db2237e6bf.png)

_I would have split this PR up, but as I'm fixing classNames, it'd make PR'ing the updated styles harder as they'd need to match the old classes, new classes, or both._