### PR TITLE
Prevent saving social links while a favicon is being fetched

### DIFF
--- a/js/src/forum/components/SocialButtonsModal.js
+++ b/js/src/forum/components/SocialButtonsModal.js
@@ -30,6 +30,8 @@ export default class SocialButtonsModal extends Modal {
     }
 
     content() {
+        const areAnyIconsBeingFetched = this.buttons.some((button) => button.icon() === 'fas fa-circle-notch fa-spin');
+
         return (
             <div className="Modal-body">
                 <div className="Form">
@@ -58,6 +60,11 @@ export default class SocialButtonsModal extends Modal {
                                 style: 'float: right;',
                                 className: 'Button Button--primary EditSocialButtons-save',
                                 loading: this.loading,
+                                // Disable save button if favicons are being fetched
+                                disabled: areAnyIconsBeingFetched,
+                                title: areAnyIconsBeingFetched
+                                    ? app.translator.trans('fof-socialprofile.forum.edit.save_disabled_fetching_favicons')
+                                    : null,
                             },
                             app.translator.trans('fof-socialprofile.forum.edit.submit')
                         )}

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -9,3 +9,4 @@ fof-socialprofile:
       submit: Save
       delete: Delete
       deletetitle: Delete Button
+      save_disabled_fetching_favicons: One or more icons are being fetched. Please wait.


### PR DESCRIPTION
Fixes #17

Adds a check so that if any link icons are set to the loading icon, the modal can't be saved.